### PR TITLE
Differentiate between different runs of the same phase in the compilation pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ else
  GRADLE=gradle
 endif
 
+.PHONY: build
+build: graal.instrumented.jar
+
 blood/build/libs/blood-all.jar: $(shell find blood/src/)
 	cd blood; ${GRADLE} shadowJar
 
@@ -30,9 +33,6 @@ graal/compiler/mxbuild/dists/jdk11/graal.jar: mx/.git graal/.git
 	
 graal.instrumented.jar: graal/compiler/mxbuild/dists/jdk11/graal.jar PLuG/dist/PLuG.jar blood/build/libs/blood-all.jar
 	PLuG/plug.sh blood/build/libs/blood-all.jar --in graal/compiler/mxbuild/dists/jdk11/graal.jar --out graal.instrumented.jar
-
-.PHONY: build
-build: graal.instrumented.jar
 
 .PHONY: clean
 clean:

--- a/blood/src/main/java/cz/cuni/mff/d3s/blood/dependencyMatrix/CustomNodeTracker.java
+++ b/blood/src/main/java/cz/cuni/mff/d3s/blood/dependencyMatrix/CustomNodeTracker.java
@@ -53,7 +53,7 @@ public class CustomNodeTracker implements NodeTracker {
             var creationPhase = getCreationPhase(node);
             if (creationPhase.isError()) {
                 System.err.println(creationPhase.unwrapError());
-            } else if (creationPhase.unwrap().equals(NoPhaseDummy.class)) {
+            } else if (creationPhase.unwrap() == NO_PHASE_DUMMY_PHASE_ID) {
                 setCreationPhase(node, phaseID);
             }
         }

--- a/blood/src/main/java/cz/cuni/mff/d3s/blood/dependencyMatrix/CustomNodeTracker.java
+++ b/blood/src/main/java/cz/cuni/mff/d3s/blood/dependencyMatrix/CustomNodeTracker.java
@@ -27,10 +27,10 @@ public class CustomNodeTracker implements NodeTracker {
     }
 
     @Override
-    public Result<Class<?>, String> getCreationPhase(Node node) {
+    public Result<PhaseID, String> getCreationPhase(Node node) {
         try {
             PhaseSourceNodeAnnotation source = (PhaseSourceNodeAnnotation) getNodeInfo.invoke(node, PhaseSourceNodeAnnotation.class);
-            return Result.success(source != null ? source.getSource() : NoPhaseDummy.class);
+            return Result.success(source != null ? source.getSource() : NodeTracker.NO_PHASE_DUMMY_PHASE_ID);
         } catch (IllegalAccessException | InvocationTargetException e) {
             StringWriter stringWriter = new StringWriter();
             e.printStackTrace(new PrintWriter(stringWriter));
@@ -38,23 +38,23 @@ public class CustomNodeTracker implements NodeTracker {
         }
     }
 
-    public void setCreationPhase(Node node, Class<?> phaseClass) {
+    public void setCreationPhase(Node node, PhaseID phaseID) {
         try {
-            setNodeInfo.invoke(node, PhaseSourceNodeAnnotation.class, new PhaseSourceNodeAnnotation(phaseClass));
+            setNodeInfo.invoke(node, PhaseSourceNodeAnnotation.class, new PhaseSourceNodeAnnotation(phaseID));
         } catch (IllegalAccessException | InvocationTargetException e) {
             e.printStackTrace();
         }
     }
 
     @Override
-    public void updateCreationPhase(Iterable<Node> nodes, Class<?> sourceClass) {
+    public void updateCreationPhase(Iterable<Node> nodes, PhaseID phaseID) {
         // mark all nodes without any creation annotation as created in this phase
         for (Node node : nodes) {
             var creationPhase = getCreationPhase(node);
             if (creationPhase.isError()) {
                 System.err.println(creationPhase.unwrapError());
             } else if (creationPhase.unwrap().equals(NoPhaseDummy.class)) {
-                setCreationPhase(node, sourceClass);
+                setCreationPhase(node, phaseID);
             }
         }
     }

--- a/blood/src/main/java/cz/cuni/mff/d3s/blood/dependencyMatrix/DefaultNodeTracker.java
+++ b/blood/src/main/java/cz/cuni/mff/d3s/blood/dependencyMatrix/DefaultNodeTracker.java
@@ -81,13 +81,13 @@ public class DefaultNodeTracker implements NodeTracker {
     }
 
     @Override
-    public Result<Class<?>, String> getCreationPhase(Node node) {
+    public Result<PhaseID, String> getCreationPhase(Node node) {
         ClassLoader classLoader = node.getClass().getClassLoader();
 
         Result<StackTraceElement[], String> traceResult = getCreationStackTrace(node);
 
         if (traceResult == null) {
-            return Result.success(DeletedPhaseDummy.class);
+            return Result.success(NodeTracker.DELETED_PHASE_DUMMY_PHASE_ID);
         }
 
         if (traceResult.isError()) {
@@ -101,11 +101,12 @@ public class DefaultNodeTracker implements NodeTracker {
                 .map(Result::unwrap)
                 .filter(BasePhase.class::isAssignableFrom)
                 .findFirst()
-                .orElse(NoPhaseDummy.class));
+                .map(aClass -> new PhaseID(aClass, 0))
+                .orElse(NodeTracker.NO_PHASE_DUMMY_PHASE_ID));
     }
 
     @Override
-    public void updateCreationPhase(Iterable<Node> nodes, Class<?> phaseClass) {
+    public void updateCreationPhase(Iterable<Node> nodes, PhaseID phaseID) {
         // We don't need to mark nodes, as Graal does it for us.
     }
 }

--- a/blood/src/main/java/cz/cuni/mff/d3s/blood/dependencyMatrix/NodeTracker.java
+++ b/blood/src/main/java/cz/cuni/mff/d3s/blood/dependencyMatrix/NodeTracker.java
@@ -2,12 +2,16 @@ package cz.cuni.mff.d3s.blood.dependencyMatrix;
 
 import cz.cuni.mff.d3s.blood.utils.Result;
 import org.graalvm.compiler.graph.Node;
+import org.graalvm.compiler.phases.BasePhase;
 
 /**
  * Objects implementing this interface are capable of tracking nodes between
  * compilation phases.
  */
 public interface NodeTracker {
+
+    public static final PhaseID DELETED_PHASE_DUMMY_PHASE_ID = new PhaseID(DeletedPhaseDummy.class, 0);
+    public static final PhaseID NO_PHASE_DUMMY_PHASE_ID = new PhaseID(NoPhaseDummy.class, 0);
 
     /**
      * Should be called right after the {@link Node} class is initialized.
@@ -20,15 +24,15 @@ public interface NodeTracker {
      * @param node the node in question
      * @return class of the phase, or a dummy, or an error message
      */
-    Result<Class<?>, String> getCreationPhase(Node node);
+    Result<PhaseID, String> getCreationPhase(Node node);
 
     /**
      * Should be called after every phase.
      *
-     * @param nodes list of nodes in the graph
-     * @param phaseClass class of the phase in question
+     * @param nodes   list of nodes in the graph
+     * @param phaseID id of the phase in question
      */
-    void updateCreationPhase(Iterable<Node> nodes, Class<?> phaseClass);
+    void updateCreationPhase(Iterable<Node> nodes, PhaseID phaseID);
 
     /**
      * Replaces phase class in cases, where the node creation stack trace was

--- a/blood/src/main/java/cz/cuni/mff/d3s/blood/dependencyMatrix/PhaseID.java
+++ b/blood/src/main/java/cz/cuni/mff/d3s/blood/dependencyMatrix/PhaseID.java
@@ -34,4 +34,12 @@ public class PhaseID {
     public int hashCode() {
         return Objects.hash(phaseClass, sequenceNumber);
     }
+
+    @Override
+    public String toString() {
+        return "PhaseID{" +
+                "phaseClass=" + phaseClass +
+                ", sequenceNumber=" + sequenceNumber +
+                '}';
+    }
 }

--- a/blood/src/main/java/cz/cuni/mff/d3s/blood/dependencyMatrix/PhaseID.java
+++ b/blood/src/main/java/cz/cuni/mff/d3s/blood/dependencyMatrix/PhaseID.java
@@ -1,0 +1,37 @@
+package cz.cuni.mff.d3s.blood.dependencyMatrix;
+
+import org.graalvm.compiler.phases.BasePhase;
+
+import java.util.Objects;
+
+public class PhaseID {
+    final Class<?> phaseClass;
+    final int sequenceNumber;
+
+    public PhaseID(Class<?> phaseClass, int sequenceNumber) {
+        this.phaseClass = phaseClass;
+        this.sequenceNumber = sequenceNumber;
+    }
+
+    public Class<?> getPhaseClass() {
+        return phaseClass;
+    }
+
+    public int getSequenceNumber() {
+        return sequenceNumber;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PhaseID phaseID = (PhaseID) o;
+        return sequenceNumber == phaseID.sequenceNumber &&
+                phaseClass.equals(phaseID.phaseClass);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(phaseClass, sequenceNumber);
+    }
+}

--- a/blood/src/main/java/cz/cuni/mff/d3s/blood/dependencyMatrix/PhaseSourceNodeAnnotation.java
+++ b/blood/src/main/java/cz/cuni/mff/d3s/blood/dependencyMatrix/PhaseSourceNodeAnnotation.java
@@ -2,13 +2,13 @@ package cz.cuni.mff.d3s.blood.dependencyMatrix;
 
 public final class PhaseSourceNodeAnnotation {
 
-    final Class<?> source;
+    final PhaseID source;
 
-    public PhaseSourceNodeAnnotation(Class<?> source) {
+    public PhaseSourceNodeAnnotation(PhaseID source) {
         this.source = source;
     }
 
-    public Class<?> getSource() {
+    public PhaseID getSource() {
         return source;
     }
 }


### PR DESCRIPTION
Some phases run multiple times during one compilation event. We should differentiate between those runs. This PR tries to fix that.